### PR TITLE
[Parallax-7] Add Profiling Option

### DIFF
--- a/doc/parallax_api.md
+++ b/doc/parallax_api.md
@@ -38,21 +38,26 @@ ParallaxConfig(run_option=None, average_sparse=False, sess_config=None, redirect
 	* ckpt_dir: The checkpoint directory to store/restore global variables.
 	* save_ckpt_steps: The frequency, in number of global steps, that a checkpoint is saved using a default checkpoint saver.
 	* save_ckpt_secs: The frequency, in seconds, that a checkpoint is saved using a default checkpoint saver.
-
+* profile_config: The configuration for profile. CUPTI library path (e.g., /usr/local/cuda/extras/CUPTI/lib64) needs to be added to LD_LIBRARY_PATH
+        * profile_dir: Then profile diretory to store RunMetadata.
+        * profile_steps: A list of steps when to store RunMetadata.
 Below code is an example of how to use **ParallaxConfig**.
 ```
-ckpt_config = parallax.CheckPointConfig(ckpt_dir=FLAGS.ckpt_dir,
+ckpt_config = parallax.CheckPointConfig(ckpt_dir=ckpt_dir,
                                         save_ckpt_steps=save_ckpt_steps)
-ps_config = parallax.PSConfig(replicate_variables=FLAGS.replicate_variables,
-                              protocol=FLAGS.protocol)
-mpi_config = parallax.MPIConfig(use_allgatherv=FLAGS.use_allgatherv,
-                                mpirun_options=FLAGS.mpirun_options)
+ps_config = parallax.PSConfig(replicate_variables=replicate_variables,
+                              protocol=protocol)
+mpi_config = parallax.MPIConfig(use_allgatherv=use_allgatherv,
+                                mpirun_options=mpirun_options)
+profile_config = parallax.ProfileConfig(profile_dir=/tmp/profile,
+                                        profile_steps=[100,200,300])
 parallax_config = parallax.Config()
-parallax_config.run_option = FLAGS.run_option,
+parallax_config.run_option = run_option,
 parallax_config.average_sparse = False
-parallax_config.redirect_path = FLAGS.redirect_path
+parallax_config.redirect_path = redirect_path
 parallax_config.communication_config = parallax.CommunicationConfig(ps_config, mpi_config)
-parallax_config.ckpt_config=ckpt_config
+parallax_config.ckpt_config = ckpt_config
+parallax_config.profile_config = profile_config
 ...
 parallel_run(..., parallax_config=parallax_config)
 ```

--- a/doc/parallax_api.md
+++ b/doc/parallax_api.md
@@ -39,7 +39,7 @@ ParallaxConfig(run_option=None, average_sparse=False, sess_config=None, redirect
 	* save_ckpt_steps: The frequency, in number of global steps, that a checkpoint is saved using a default checkpoint saver.
 	* save_ckpt_secs: The frequency, in seconds, that a checkpoint is saved using a default checkpoint saver.
 * profile_config: The configuration for profile. CUPTI library path (e.g., /usr/local/cuda/extras/CUPTI/lib64) needs to be added to LD_LIBRARY_PATH
-        * profile_dir: Then profile diretory to store RunMetadata.
+        * profile_dir: Then profile directory to store RunMetadata.
         * profile_steps: A list of steps when to store RunMetadata.
 Below code is an example of how to use **ParallaxConfig**.
 ```

--- a/parallax/parallax/__init__.py
+++ b/parallax/parallax/__init__.py
@@ -22,3 +22,4 @@ from parallax.core.python.common.config import PSConfig
 from parallax.core.python.common.config import MPIConfig
 from parallax.core.python.common.config import CommunicationConfig
 from parallax.core.python.common.config import CheckPointConfig
+from parallax.core.python.common.config import ProfileConfig

--- a/parallax/parallax/core/python/common/BUILD
+++ b/parallax/parallax/core/python/common/BUILD
@@ -32,6 +32,13 @@ native.py_library(
 )
 
 native.py_library(
+    name = "session_context",
+    srcs = ["session_context.py"],
+    deps = [
+    ]
+)
+
+native.py_library(
     name = "runner",
     srcs = ["runner.py"],
     deps = [
@@ -66,6 +73,7 @@ native.py_library(
         "runner",
         "shard",
         "config",
+        "session_context",
     ],
 )
 

--- a/parallax/parallax/core/python/common/config.py
+++ b/parallax/parallax/core/python/common/config.py
@@ -92,6 +92,18 @@ class CheckPointConfig(object):
         self.save_ckpt_steps = save_ckpt_steps
         self.save_ckpt_secs = save_ckpt_secs
 
+class ProfileConfig(object):
+    def __init__(self,
+                 profile_dir=None,
+                 profile_steps=None):
+    
+        """
+        Args:
+          profile_dir: The profile directory to store RunMetadata.
+          profile_steps: A list of steps when to store RunMetadata.
+        """
+        self.profile_dir = profile_dir
+        self.profile_steps = profile_steps
 
 class ParallaxConfig(object):
     def __init__(self,
@@ -100,7 +112,8 @@ class ParallaxConfig(object):
                  sess_config=None,
                  redirect_path=None,
                  communication_config=CommunicationConfig(),
-                 ckpt_config=CheckPointConfig()):
+                 ckpt_config=CheckPointConfig(),
+                 profile_config=ProfileConfig()):
         """Configurable options of Parallax.
 
         Args:
@@ -115,7 +128,8 @@ class ParallaxConfig(object):
           communication_config: A `CommunicationConfig` object to manage the
             configurations related to communication.
           ckpt_config: A `CheckPointConfig` object to manage the checkpoints
- 
+          profile_config: A `ProfileConfig` object to manage profile
+
         """
 
         self.run_option = run_option
@@ -125,6 +139,7 @@ class ParallaxConfig(object):
 
         self.communication_config = communication_config
         self.ckpt_config = ckpt_config
+        self.profile_config = profile_config
 
         self._sync = None
         self._num_iterations = None

--- a/parallax/parallax/core/python/common/config.py
+++ b/parallax/parallax/core/python/common/config.py
@@ -96,7 +96,6 @@ class ProfileConfig(object):
     def __init__(self,
                  profile_dir=None,
                  profile_steps=None):
-    
         """
         Args:
           profile_dir: The profile directory to store RunMetadata.
@@ -129,7 +128,6 @@ class ParallaxConfig(object):
             configurations related to communication.
           ckpt_config: A `CheckPointConfig` object to manage the checkpoints
           profile_config: A `ProfileConfig` object to manage profile
-
         """
 
         self.run_option = run_option

--- a/parallax/parallax/core/python/common/session_context.py
+++ b/parallax/parallax/core/python/common/session_context.py
@@ -61,7 +61,7 @@ def _parallax_run(self,
 class ParallaxSessionContext(object):
     """A context that wraps session for Parallax.
        
-       This class references tf.contrib.tfprof.ProfileContext class.
+    This class references tf.contrib.tfprof.ProfileContext class.
 
     Args:
         profile_dir: Directory to store profiles.

--- a/parallax/parallax/core/python/common/session_context.py
+++ b/parallax/parallax/core/python/common/session_context.py
@@ -1,0 +1,130 @@
+# Copyright (C) 2018 Seoul National University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import contextlib
+import os
+import threading
+
+import tensorflow as tf
+from tensorflow.python import pywrap_tensorflow as print_mdl
+from tensorflow.python.client import session
+
+def _parallax_init(self, target='', graph=None, config=None):
+    """Overwrites the session.__init__."""
+    self._init_internal(target, graph, config)  # pylint: disable=protected-access
+
+
+def _parallax_run(self,
+                  fetches,
+                  feed_dict=None,
+                  options=None,
+                  run_metadata=None):
+    if (self.parallax_session_context._profile_dir is None 
+        or self.parallax_session_context._profile_steps is None):
+        return self._run_internal(fetches, feed_dict)
+
+    with self.parallax_session_context._new_step() as state:
+        step, locked = state
+        if locked and self.parallax_session_context._is_profile_step(step):
+            if not run_metadata:
+                run_metadata = tf.RunMetadata()
+            if not options:
+                options = tf.RunOptions(
+                    trace_level=tf.RunOptions.FULL_TRACE)
+                old_trace_level = options.trace_level
+            else:
+                old_trace_level = options.trace_level
+                options.trace_level = tf.RunOptions.FULL_TRACE
+                
+            ret = self._run_internal(
+                fetches, feed_dict, options, run_metadata)
+            self.parallax_session_context._dump_profile(
+                run_metadata, 'run_meta_%d' % step)
+            options.trace_level = old_trace_level
+        else:
+            ret = self._run_internal(fetches, feed_dict)
+
+    return ret          
+                      
+class ParallaxSessionContext(object):
+    """A context that wraps session for Parallax.
+       
+       This class references tf.contrib.tfprof.ProfileContext class.
+
+    Args:
+        profile_dir: Directory to store profiles.
+        profile_steps: A list of steps for tracing and saving as a file.
+    """
+   
+    def __init__(self,
+                 step,
+                 profile_dir,
+                 profile_steps):
+
+        self._step = step
+        self._profile_dir = profile_dir
+        self._profile_steps = profile_steps
+        
+        self._lock = threading.Lock()
+    
+    @contextlib.contextmanager
+    def _new_step(self):
+        acquired = self._lock.acquire(False)
+        yield (self._step, acquired)
+        self._step += 1
+        if acquired:
+            self._lock.release()
+ 
+    def _is_profile_step(self, step):
+      if step in self._profile_steps:
+        return True
+      return False
+
+    def _dump_profile(self, metadata, basename):
+      if not tf.gfile.Exists(self._profile_dir):
+          tf.gfile.MakeDirs(self._profile_dir)
+      with tf.gfile.Open(os.path.join(self._profile_dir, basename), 'w') as f:
+          f.write('%s' % metadata)
+
+    def __enter__(self):
+      self.old_run = getattr(session.BaseSession, 'run', None)
+      self.old_init = getattr(session.BaseSession, '__init__', None)
+      if not self.old_run:
+        raise tf.errors.InternalError(None, None, 'BaseSession misses run method.')
+      elif not self.old_init:
+        raise tf.errors.InternalError(None, None,
+                                   'BaseSession misses __init__ method.')
+      elif getattr(session.BaseSession, '_run_internal', None):
+        raise tf.errors.InternalError(None, None,
+                                   'Already in context or context not cleaned.')
+      elif getattr(session.BaseSession, '_init_internal', None):
+        raise tf.errors.InternalError(None, None,
+                                   'Already in context or context not cleaned.')
+      else:
+        setattr(session.BaseSession, 'run', _parallax_run)
+        setattr(session.BaseSession, '__init__', _parallax_init)
+        setattr(session.BaseSession, '_run_internal', self.old_run)
+        setattr(session.BaseSession, '_init_internal', self.old_init)
+        setattr(session.BaseSession, 'parallax_session_context', self)
+        return self
+     
+    
+    def __exit__(self, exec_type, exec_value, exec_tb):
+        print_mdl.DeleteProfiler()
+        setattr(session.BaseSession, 'run', self.old_run)
+        setattr(session.BaseSession, '__init__', self.old_init)
+        setattr(session.BaseSession, '_run_internal', None)
+        setattr(session.BaseSession, '_init_internal', None)
+        setattr(session.BaseSession, 'parallax_session_context', None)    

--- a/parallax/parallax/core/python/mpi/BUILD
+++ b/parallax/parallax/core/python/mpi/BUILD
@@ -22,6 +22,7 @@ native.py_library(
         "graph_transform",
         "//parallax/core/python/common:lib",
         "//parallax/core/python/common:consts",
+        "//parallax/core/python/common:session_context",
     ]
 )
 

--- a/parallax/parallax/core/python/mpi/runner.py
+++ b/parallax/parallax/core/python/mpi/runner.py
@@ -29,6 +29,7 @@ import horovod.tensorflow as hvd
 
 from parallax.core.python.common.lib import *
 from parallax.core.python.common.consts import *
+from parallax.core.python.common.session_context import ParallaxSessionContext
 from parallax.core.python.mpi.graph_transform import graph_transform_mpi
 
 def create_mpi_script(driver_path, args, hostname, gpus, port=22):
@@ -156,24 +157,30 @@ def parallax_run_mpi(single_gpu_meta_graph_def, run, config, is_test,
                 save_summaries_steps=None,
                 save_summaries_secs=None,
                 config=sess_config) as sess:
+
             parallax_log.debug(
                 "Created MonitoredTrainingSession for worker %d" % worker_id)
             _init_global_vars(sess)
             parallax_log.debug(
-                "Finished initialization process, start training on worker %d"
-                % worker_id)
+                "Finished initialization process, start training on \
+                 worker %d" % worker_id)
+            step = sess.run(tf.get_collection(tf.GraphKeys.GLOBAL_STEP)[0])
+            with ParallaxSessionContext(step,
+                                        config.profile_config.profile_dir,
+                                        config.profile_config.profile_steps):
 
-            if is_test:
-                parallax_log.debug('warmup is started')
-                run(sess, NUM_ITERATIONS_FOR_WARMUP,
-                    tensor_or_op_name_to_replica_names, num_workers,
-                    worker_id, 1)
-                parallax_log.debug('warmup is ended')
+                if is_test:
+                    parallax_log.debug('warmup is started')
+                    run(sess, NUM_ITERATIONS_FOR_WARMUP,
+                        tensor_or_op_name_to_replica_names, num_workers,
+                        worker_id, 1)
+                    parallax_log.debug('warmup is ended')
 
-            start_time = time.time()
-            run(sess, config.num_iterations(is_test), tensor_or_op_name_to_replica_names,
-                num_workers, worker_id, 1)
-            end_time = time.time()
+                start_time = time.time()
+                run(sess, config.num_iterations(is_test), 
+                    tensor_or_op_name_to_replica_names,
+                    num_workers, worker_id, 1)
+                end_time = time.time()
 
             if is_test:
                 send_execution_time(config.resource_info['master'][0], worker_id,

--- a/parallax/parallax/core/python/ps/runner.py
+++ b/parallax/parallax/core/python/ps/runner.py
@@ -27,6 +27,7 @@ import tensorflow as tf
 from parallax.core.python.common import graph_transform_lib
 from parallax.core.python.common.lib import *
 from parallax.core.python.common.consts import *
+from parallax.core.python.common.session_context import ParallaxSessionContext
 from parallax.core.python.ps.graph_transform import graph_transform_ps
 
 
@@ -256,17 +257,22 @@ def parallax_run_ps(single_gpu_meta_graph_def, run, config, is_test,
                 "Finished initialization process, start training on worker %d"
                 % worker_id)
 
-            if is_test:
-                parallax_log.debug('warmup is started')
-                run(sess, NUM_ITERATIONS_FOR_WARMUP,
-                    tensor_or_op_name_to_replica_names, num_workers, worker_id,
-                    num_replicas_per_worker)
-                parallax_log.debug('warmup is ended')
+            step = sess.run(tf.get_collection(tf.GraphKeys.GLOBAL_STEP)[0])
+            with ParallaxSessionContext(step,
+                                        config.profile_config.profile_dir,
+                                        config.profile_config.profile_steps):
+                if is_test:
+                    parallax_log.debug('warmup is started')
+                    run(sess, NUM_ITERATIONS_FOR_WARMUP,
+                        tensor_or_op_name_to_replica_names, num_workers, 
+                        worker_id, num_replicas_per_worker)
+                    parallax_log.debug('warmup is ended')
 
-            start_time = time.time()
-            run(sess, config.num_iterations(is_test), tensor_or_op_name_to_replica_names,
-                num_workers, worker_id, num_replicas_per_worker)
-            end_time = time.time()
+                start_time = time.time()
+                run(sess, config.num_iterations(is_test), 
+                    tensor_or_op_name_to_replica_names,
+                    num_workers, worker_id, num_replicas_per_worker)
+                end_time = time.time()
 
             if is_test:
                 send_execution_time(config.resource_info['master'][0], worker_id,

--- a/parallax/parallax/examples/lm1b/parallax_config.py
+++ b/parallax/parallax/examples/lm1b/parallax_config.py
@@ -29,6 +29,8 @@ flags.DEFINE_string('ckpt_dir', None, """Directory to save checkpoints""")
 flags.DEFINE_integer('save_ckpt_steps', None,
                      """Number of steps between two consecutive checkpoints""")
 flags.DEFINE_integer('save_n_ckpts_per_epoch', -1, """Save n checkpoints per every epoch""")
+flags.DEFINE_string('profile_dir', None, """Directory to save RunMetadata""")
+flags.DEFINE_string('profile_steps', None, """Comma separated porfile steps""")
 FLAGS = flags.FLAGS
 
 def calculate_ckpt_steps():
@@ -53,11 +55,19 @@ def build_config():
                                   protocol=FLAGS.protocol)
     mpi_config = parallax.MPIConfig(use_allgatherv=FLAGS.use_allgatherv,
                                     mpirun_options=FLAGS.mpirun_options)
+    def get_profile_steps():
+        if not FLAGS.profile_steps:
+            return []
+        FLAGS.profile_steps = FLAGS.profile_steps.strip()
+        return [int(step) for step in FLAGS.profile_steps.split(',')]
+    profile_config = parallax.ProfileConfig(profile_dir=FLAGS.profile_dir,
+                                            profile_steps=get_profile_steps())
     parallax_config = parallax.Config()
     parallax_config.run_option = FLAGS.run_option
     parallax_config.average_sparse = False
     parallax_config.communication_config = parallax.CommunicationConfig(ps_config, mpi_config)
-    parallax_config.ckpt_config=ckpt_config
+    parallax_config.ckpt_config = ckpt_config
+    parallax_config.profile_config = profile_config
     parallax_config.redirect_path = FLAGS.redirect_path
 
     return parallax_config

--- a/parallax/parallax/examples/nmt/parallax_config.py
+++ b/parallax/parallax/examples/nmt/parallax_config.py
@@ -30,6 +30,8 @@ flags.DEFINE_integer('save_ckpt_steps', None,
                      """Number of steps between two consecutive checkpoints""")
 flags.DEFINE_integer('save_n_ckpts_per_epoch', -1, """Save n checkpoints per every epoch""")
 flags.DEFINE_string('ckpt_dir', None, """Directory to save checkpoints""")
+flags.DEFINE_string('profile_dir', None, """Directory to save RunMetadata""")
+flags.DEFINE_string('profile_steps', None, """Comma separated porfile steps""")
 FLAGS = flags.FLAGS
 
 def calculate_ckpt_steps():
@@ -58,7 +60,15 @@ def build_config():
     parallax_config.run_option = FLAGS.run_option
     parallax_config.average_sparse = False
     parallax_config.communication_config = parallax.CommunicationConfig(ps_config, mpi_config)
-    parallax_config.ckpt_config=ckpt_config
+    parallax_config.ckpt_config = ckpt_config
+    def get_profile_steps():
+        if not FLAGS.profile_steps:
+            return []
+        FLAGS.profile_steps = FLAGS.profile_steps.strip()
+        return [int(step) for step in FLAGS.profile_steps.split(',')]
+    profile_config = parallax.ProfileConfig(profile_dir=FLAGS.profile_dir,
+                                            profile_steps=get_profile_steps())
+    parallax_config.profile_config = profile_config
     parallax_config.redirect_path = FLAGS.redirect_path
 
     return parallax_config

--- a/parallax/parallax/examples/skip_thoughts/parallax_config.py
+++ b/parallax/parallax/examples/skip_thoughts/parallax_config.py
@@ -28,6 +28,8 @@ flags.DEFINE_string('redirect_path', None, """redirect path to keep the log of d
 flags.DEFINE_string('ckpt_dir', None, """Directory to save checkpoints""")
 flags.DEFINE_integer('save_ckpt_steps', None,
                      """Number of steps between two consecutive checkpoints""")
+flags.DEFINE_string('profile_dir', None, """Directory to save RunMetadata""")
+flags.DEFINE_string('profile_steps', None, """Comma separated porfile steps""")
 FLAGS = flags.FLAGS
 
 def build_config():
@@ -43,6 +45,14 @@ def build_config():
     parallax_config.average_sparse = False
     parallax_config.communication_config = parallax.CommunicationConfig(ps_config, mpi_config)
     parallax_config.ckpt_config=ckpt_config
+    def get_profile_steps():
+        if not FLAGS.profile_steps:
+            return []
+        FLAGS.profile_steps = FLAGS.profile_steps.strip()
+        return [int(step) for step in FLAGS.profile_steps.split(',')]
+    profile_config = parallax.ProfileConfig(profile_dir=FLAGS.profile_dir,
+                                            profile_steps=get_profile_steps())
+    parallax_config.profile_config = profile_config
     parallax_config.redirect_path = FLAGS.redirect_path
 
     return parallax_config

--- a/parallax/parallax/examples/tf_cnn_benchmarks/parallax_config.py
+++ b/parallax/parallax/examples/tf_cnn_benchmarks/parallax_config.py
@@ -30,6 +30,8 @@ flags.DEFINE_integer('save_ckpt_steps', None,
                      """Number of steps between two consecutive checkpoints""")
 flags.DEFINE_integer('save_n_ckpts_per_epoch', -1, """Save n checkpoints per every epoch""")
 flags.DEFINE_string('ckpt_dir', None, """Directory to save checkpoints""")
+flags.DEFINE_string('profile_dir', None, """Directory to save RunMetadata""")
+flags.DEFINE_string('profile_steps', None, """Comma separated porfile steps""")
 FLAGS = flags.FLAGS
 
 def calculate_ckpt_steps():
@@ -54,11 +56,20 @@ def build_config():
                                   protocol=FLAGS.protocol)
     mpi_config = parallax.MPIConfig(use_allgatherv=FLAGS.use_allgatherv,
                                     mpirun_options=FLAGS.mpirun_options)
+    def get_profile_steps():
+        if not FLAGS.profile_steps:
+            return []
+        FLAGS.profile_steps = FLAGS.profile_steps.strip()
+        return [int(step) for step in FLAGS.profile_steps.split(',')]
+    profile_config = parallax.ProfileConfig(profile_dir=FLAGS.profile_dir,
+                                            profile_steps=get_profile_steps())
+
     parallax_config = parallax.Config()
     parallax_config.run_option = FLAGS.run_option
     parallax_config.average_sparse = False
     parallax_config.communication_config = parallax.CommunicationConfig(ps_config, mpi_config)
     parallax_config.ckpt_config=ckpt_config
+    parallax_config.profile_config = profile_config
     parallax_config.redirect_path = FLAGS.redirect_path
 
     return parallax_config


### PR DESCRIPTION
Github issue: #7 

**Major changes:**
- Add Profile option into ParallaxConfig

**Minor changes to note:**
- Remove `Flags` in API document 

**Tests for the changes:**
- Add `--profile_dir` and `--profile_steps` when running example codes
- CUPTI(/usr/local/cuda/extras/CUPTI/lib64) library path must be added LD_LIBRARY_PATH. As other environment variables, LD_LIBRARY_PATH must be set in `.ssh/environment`.

**Other comments:**
- 

resolves #7
