### PR TITLE
Bugfix: kill launch_ps

### DIFF
--- a/parallax/parallax/core/python/common/runner.py
+++ b/parallax/parallax/core/python/common/runner.py
@@ -82,7 +82,7 @@ def _parallax_run_master(single_gpu_meta_graph_def,
 
             # kill processes if the chief worker receives average
             # exectution time using PS
-            os.killpg(os.getpgid(chief_worker_process.pid), signal.SIGINT)
+            cleanup(None, None)
 
             parallax_log.debug('mpi exec time : %d secs, \
                                ps exec time: %d secs'

--- a/parallax/parallax/core/python/ps/runner.py
+++ b/parallax/parallax/core/python/ps/runner.py
@@ -181,7 +181,8 @@ def launch_ps_driver(driver_path, args, config, is_test):
         processes.append(ps_proc)
 
     def cleanup_ps(recv_signal, frame):
-        os.killpg(os.getpgid(chief_worker_process.pid), signal.SIGINT)
+        for process in processes:
+            os.killpg(os.getpgid(process.pid), signal.SIGINT)
 
     signal.signal(signal.SIGINT, cleanup_ps)
     return chief_worker_process, logfiles, cleanup_ps


### PR DESCRIPTION
Github issue: #8 

**Major changes:**
- Fix bug to kill launch_ps process clearly.

**Minor changes to note:**
N/A

**Tests for the changes:**
- Run example apps with `run_option=PS`, send SIGINT to terminate, and verify whether `launch_ps` processes are killed or not, using `ps aux | grep python | grep launch_ps`

**Other comments:**
N/A

resolves #9 
