### PR TITLE
[Parallax-13] Change 'run_metadata' saving format

### DIFF
--- a/parallax/parallax/core/python/common/session_context.py
+++ b/parallax/parallax/core/python/common/session_context.py
@@ -95,8 +95,8 @@ class ParallaxSessionContext(object):
     def _dump_profile(self, metadata, basename):
       if not tf.gfile.Exists(self._profile_dir):
           tf.gfile.MakeDirs(self._profile_dir)
-      with tf.gfile.Open(os.path.join(self._profile_dir, basename), 'w') as f:
-          f.write('%s' % metadata)
+      with tf.gfile.Open(os.path.join(self._profile_dir, basename), 'wb') as f:
+          f.write(metadata.SerializeToString())
 
     def __enter__(self):
       self.old_run = getattr(session.BaseSession, 'run', None)


### PR DESCRIPTION
Github issue: #13 

**Major changes:**
- This PR changes saving format of 'run_metadata'.
- Now, metadata is saved with `metadata.SerializeToString()` instead of `str(metadata)`.
- This change enables easy loading of the saved data with TF's API 
   (`metadata.MergeFromString()`).

**Minor changes to note:**
- 

**Tests for the changes:**
- 

**Other comments:**
- 

resolves #13 
