### PR TITLE
[Parallax-24] Automatic variable partitioning

### DIFF
--- a/doc/parallax_api.md
+++ b/doc/parallax_api.md
@@ -42,13 +42,15 @@ Example (assume `num_replicas_per_worker` is 3)
 
 ```shell
 ParallaxConfig(run_option=None, average_sparse=False, sess_config=None, redirect_path=None, 
-               communication_config=CommunicationConfig(), ckpt_config=CheckPointConfig())
+               search_partitions=False, communication_config=CommunicationConfig(), 
+               ckpt_config=CheckPointConfig())
 ```
 
 * run_option:  A string(PS, MPI or HYBRID). The communication method for training.
 * average_sparse: A boolean. If True, sparse parameters are updated by the averaged gradients over all replicas. Otherwise, the sum of all gradients are used.
 * sess_config: The session configuration used in `tf.train.MonitoredTrainingSession`
 * redirect_path: A string. Optional path to redirect logs as files.
+* search_partitions: A boolean. If True and there is a Parallax partitioner, Parallax's automatic partitioning mechanism is activated. Otherwise, the partitioning is turned off.
 * communication_config: The communication configuration for PS and MPI.
 	* PSConfig
 		* protocol: Specifies the protocol to be used by the server. Acceptable values include `"grpc"`, `"grpc+gdr"`, `"grpc+verbs"`, etc. `"grpc"` is the default.
@@ -83,6 +85,7 @@ parallax_config = parallax.Config()
 parallax_config.run_option = run_option,
 parallax_config.average_sparse = False
 parallax_config.redirect_path = redirect_path
+parallax_config.search_partitions = True
 parallax_config.communication_config = parallax.CommunicationConfig(ps_config, mpi_config)
 parallax_config.ckpt_config = ckpt_config
 parallax_config.profile_config = profile_config

--- a/doc/quick_start.md
+++ b/doc/quick_start.md
@@ -88,6 +88,16 @@ slice_size = tf.cond(tf.less(shard_id, remainder), lambda: shard_size + 1,
                      lambda: shard_size)
 data_files = tf.slice(data_files, [slice_begin], [slice_size])
 ```
+## Variable partitioning
+Parallax finds a near-optimal number of partitions to maximize parallelism while maintaining low computation and communication overhead. We support `tf.fixed_size_partitioner` with the number of partitions that Parallax finds using an internal cost model that predicts iteration time as a function of the number of partitions.
+If some of the variables are assumed large enough to be partitioned, construct partitioner using `parallax.get_partitioner` with the minimum number of partitions possible without memory exceptions as an argument. By assigning `search_partitions` as True or False in ParallaxConfig, partitioning can be turned on or off. When there is a Parallax partitioner with `search_partitions=False`, the minimum number of partitions are used.
+```shell
+partitioner = parallax.get_partitioner(min_partitions)
+with tf.variable_scope(
+     "emb", partitioner=partitioner) as scope:
+     emb_v = tf.get_variable(
+          "emb_mat_var", [num_trainable_tokens, emb_size])
+```
 
 ## Setting Environment Variables
 Parallax reads the environment variables below from the machine where an application is launched. `CUDA_VISIBLE_DEVICES` is set with the information from `resource_info` so that the user defined value will be ignored.

--- a/parallax/parallax/__init__.py
+++ b/parallax/parallax/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
+from parallax.core.python.common.partitions import get_partitioner
 from parallax.core.python.common.runner import parallel_run
 from parallax.core.python.common import shard
 from parallax.core.python.common.lib import parallax_log as log

--- a/parallax/parallax/core/python/common/BUILD
+++ b/parallax/parallax/core/python/common/BUILD
@@ -45,6 +45,7 @@ native.py_library(
         "lib",
         "graph_transform_lib",
         "consts",
+        "partitions",
         "//parallax/core/python/ps:runner",
         "//parallax/core/python/mpi:runner",
         "//parallax/core/python/hybrid:runner"
@@ -67,6 +68,12 @@ native.py_library(
 )
 
 native.py_library(
+    name = "partitions",
+    srcs = ["partitions.py"],
+    deps = [
+    ],
+)
+native.py_library(
     name = "common",
     srcs = ["__init__.py"],
     deps = [
@@ -75,6 +82,7 @@ native.py_library(
         "shard",
         "config",
         "session_context",
+        "partitions"
     ],
 )
 

--- a/parallax/parallax/core/python/common/config.py
+++ b/parallax/parallax/core/python/common/config.py
@@ -127,6 +127,7 @@ class ParallaxConfig(object):
                  average_sparse=False,
                  sess_config=None,
                  redirect_path=None,
+                 search_partitions=True,
                  export_graph_path=None,
                  communication_config=CommunicationConfig(),
                  ckpt_config=CheckPointConfig(),
@@ -142,6 +143,8 @@ class ParallaxConfig(object):
           sess_config: tf.ConfigProto object to create the session with custom
             configurations.
           redirect_path: A string. Optional path to redirect logs as files.
+          search_partitions: A boolean. If true, Parallax searches optimal 
+             number of partitions for embedding parameters.
           export_graph_path: A string. Optional path to store graph.
           communication_config: A `CommunicationConfig` object to manage the
             configurations related to communication.
@@ -153,6 +156,7 @@ class ParallaxConfig(object):
         self.average_sparse = average_sparse
         self.sess_config = sess_config
         self.redirect_path = redirect_path
+        self.search_partitions = search_partitions
         self.export_graph_path = export_graph_path
 
         self.communication_config = communication_config

--- a/parallax/parallax/core/python/common/lib.py
+++ b/parallax/parallax/core/python/common/lib.py
@@ -138,14 +138,15 @@ def parse_resource_info(path, run_option):
     with open(path) as file:
         for machine_info in file:
             machines.extend(parse_machine_info(machine_info.strip()))
-
+    master_host = machines[0][0]
+    master = [{'hostname': master_host, 'port': _get_empty_port(master_host, 1), 'gpus': []}]
     ps = [{'hostname': hostname, 'port': _get_empty_port(hostname, 1), 'gpus': []} for hostname, _ in machines]
     worker = [{'hostname': hostname, 
                'port': _get_empty_port(hostname, 1 if run_option != 'HYBRID' \
                    or len(gpus) == 0 else len(gpus)), 'gpus': gpus} \
                        for hostname, gpus in machines]
 
-    resource_info = {'ps': ps, 'worker': worker}
+    resource_info = {'master': master, 'ps': ps, 'worker': worker}
     return resource_info
 
 

--- a/parallax/parallax/core/python/common/partitions.py
+++ b/parallax/parallax/core/python/common/partitions.py
@@ -79,9 +79,9 @@ class PartitionStatCollector(object):
                 worker_exec_times.append(q.get())
  
             for p in processes:
-              if p.poll() is not None:
-                  all_alive = False
-                  break
+                if p.poll() is not None:
+                    all_alive = False
+                    break
 
         cleanup(None, None)
         time.sleep(10)
@@ -93,7 +93,7 @@ class PartitionStatCollector(object):
             self.exec_time_list.append(curr_exec_time)
 
             if self.prev_p:
-		if self.prev_exec_time < curr_exec_time:
+                if self.prev_exec_time < curr_exec_time:
 		    # decrease or stop
                     if self.prev_p > curr_p:
                         stop = True
@@ -104,7 +104,7 @@ class PartitionStatCollector(object):
                     assert (self.prev_exec_time / curr_exec_time) > 1
 		    # keep increase or keep decrease
 		    if self.prev_p < curr_p:
-			    self.p_to_test *= 2
+	                self.p_to_test *= 2
 		    else:
 			self.p_to_test /= 2
 
@@ -143,8 +143,8 @@ class PartitionStatCollector(object):
         print(self.exec_time_list)
         
         if len(self.p_list) < 3:
-          min_exec_time = min(self.exec_time_list)
-          return self.p_list[self.exec_time_list.index(min_exec_time)]
+            min_exec_time = min(self.exec_time_list)
+            return self.p_list[self.exec_time_list.index(min_exec_time)]
             
         max_time = float(max(self.exec_time_list))
         exec_times = [t / max_time for t in self.exec_time_list]
@@ -158,10 +158,10 @@ class PartitionStatCollector(object):
         min_exec_time = None
         optimal_p = None
         for i in range(min_p, max_p + 1):
-          prediction = fitfunc(i, p[0], p[1], p[2])
+            prediction = fitfunc(i, p[0], p[1], p[2])
 
-          if min_exec_time is None or min_exec_time > prediction:
-            min_exec_time = prediction
-            optimal_p = i
+            if min_exec_time is None or min_exec_time > prediction:
+                min_exec_time = prediction
+                optimal_p = i
 
         return optimal_p

--- a/parallax/parallax/core/python/common/partitions.py
+++ b/parallax/parallax/core/python/common/partitions.py
@@ -21,6 +21,8 @@ import time
 
 import tensorflow as tf
 
+from parallax.core.python.common.lib import *
+
 PARALLAX_MIN_PARTITIONS = "PARALLAX_MIN_PARTITIONS"
 PARALLAX_PARTITIONS = "PARALLAX_PARTITIONS"
 PARALLAX_SEARCH = "PARALLAX_SEARCH"
@@ -56,7 +58,7 @@ class PartitionStatCollector(object):
         self.p_list = []
         self.start = None
         self.min_partitions = int(os.environ[PARALLAX_MIN_PARTITIONS])
-        
+
     def setup_manager(self):
         if self.start is None:
             self.start = time.time()

--- a/parallax/parallax/core/python/common/partitions.py
+++ b/parallax/parallax/core/python/common/partitions.py
@@ -1,0 +1,165 @@
+# Copyright (C) 2019 Seoul National University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import os
+from multiprocessing.managers import BaseManager
+import Queue
+import numpy as np
+from scipy import optimize
+import time
+
+import tensorflow as tf
+
+PARALLAX_MIN_PARTITIONS = "PARALLAX_MIN_PARTITIONS"
+PARALLAX_PARTITIONS = "PARALLAX_PARTITIONS"
+PARALLAX_SEARCH = "PARALLAX_SEARCH"
+
+#TODO: support partitioning for multiple partitioners
+#      with different number of partitions
+def get_partitioner(min_num_partitions):
+    """Return tf.fixed_size_partitioner with num_partitions
+       that determined by Parallax.
+   
+    Args:
+      min_num_partitions: A minimum (default) number of partitions 
+                          without memory exception.
+    """
+
+    if PARALLAX_MIN_PARTITIONS not in os.environ:
+       os.environ[PARALLAX_MIN_PARTITIONS] = str(min_num_partitions)
+
+    if PARALLAX_PARTITIONS in os.environ:
+        partitions = int(os.environ[PARALLAX_PARTITIONS])
+    else:
+        partitions = min_num_partitions
+    return tf.fixed_size_partitioner(partitions)
+
+class PartitionStatCollector(object):
+
+    def __init__(self, p_to_test, address):
+        self.p_to_test = p_to_test
+        self.address = address
+        self.prev_p = None
+        self.prev_exec_time = None
+        self.exec_time_list = []
+        self.p_list = []
+        self.start = None
+        self.min_partitions = int(os.environ[PARALLAX_MIN_PARTITIONS])
+        
+    def setup_manager(self):
+        if self.start is None:
+            self.start = time.time()
+        self.m = BaseManager(address=self.address, authkey='parallax_auth')
+        queue = Queue.Queue()
+        BaseManager.register('queue', callable=lambda:queue)
+        self.m.start()
+        return self.m
+
+    def recv_exec_time(self, processes, cleanup, num_required):
+        stop = False
+        worker_exec_times = []
+        all_alive = True
+        while len(worker_exec_times) != num_required and all_alive:
+            time.sleep(10)
+            q = self.m.queue()
+            while q.qsize() > 0:
+                worker_exec_times.append(q.get())
+ 
+            for p in processes:
+              if p.poll() is not None:
+                  all_alive = False
+                  break
+
+        cleanup(None, None)
+        time.sleep(10)
+
+        if all_alive:
+            curr_p = self.p_to_test
+            curr_exec_time = np.mean(worker_exec_times)
+            self.p_list.append(curr_p)
+            self.exec_time_list.append(curr_exec_time)
+
+            if self.prev_p:
+		if self.prev_exec_time < curr_exec_time:
+		    # decrease or stop
+                    if self.prev_p > curr_p:
+                        stop = True
+		    else:
+	                # search the oposite partitions
+			self.p_to_test = min(self.p_list) / 2
+		else:
+                    assert (self.prev_exec_time / curr_exec_time) > 1
+		    # keep increase or keep decrease
+		    if self.prev_p < curr_p:
+			    self.p_to_test *= 2
+		    else:
+			self.p_to_test /= 2
+
+		if self.p_to_test < self.min_partitions:
+		    stop = True
+	    else:
+		# increase first
+		self.p_to_test *= 2
+
+	    self.prev_p = curr_p
+	    self.prev_exec_time = curr_exec_time
+        else:
+            # communication error when num partitions is small
+            if self.prev_p:
+                stop = True
+            else:
+                self.p_to_test *= 2
+                self.min_partitions = self.p_to_test
+
+        if stop:
+            end = time.time()
+            self.p_to_test = self._find_optimal_p()
+            parallax_log.info('optimal partitions: %d, search time: %d secs' % \
+                (self.p_to_test, end - self.start))
+            print('optimal partitions: %d, search time: %d secs' % \
+                (self.p_to_test, end - self.start))
+
+        return not stop, self.p_to_test
+
+    def _find_optimal_p(self):
+        parallax_log.info('start finding optimal p')
+        print('start finding optimal p')
+        parallax_log.info(self.p_list)
+        print(self.p_list)
+        parallax_log.info(self.exec_time_list)
+        print(self.exec_time_list)
+        
+        if len(self.p_list) < 3:
+          min_exec_time = min(self.exec_time_list)
+          return self.p_list[self.exec_time_list.index(min_exec_time)]
+            
+        max_time = float(max(self.exec_time_list))
+        exec_times = [t / max_time for t in self.exec_time_list]
+
+        fitfunc = lambda n, a, b, c: b / n + a * (n - 1) + c
+        p, pcov = optimize.curve_fit(fitfunc, np.array(self.p_list), np.array(exec_times))
+
+        min_p = min(self.p_list)
+        max_p = max(self.p_list)
+
+        min_exec_time = None
+        optimal_p = None
+        for i in range(min_p, max_p + 1):
+          prediction = fitfunc(i, p[0], p[1], p[2])
+
+          if min_exec_time is None or min_exec_time > prediction:
+            min_exec_time = prediction
+            optimal_p = i
+
+        return optimal_p

--- a/parallax/parallax/core/python/common/runner.py
+++ b/parallax/parallax/core/python/common/runner.py
@@ -75,6 +75,8 @@ def _parallax_run_master(single_gpu_meta_graph_def,
     if config.search_partitions and PARALLAX_MIN_PARTITIONS in os.environ:
       # Set to find automatic embedding partitoning
       p_to_test = len(config.resource_info['worker'])
+      min_partitions = int(os.environ[PARALLAX_MIN_PARTITIONS])
+      p_to_test = max(min_partitions, p_to_test)
       address = (config.resource_info['master'][0]['hostname'],
                  int(config.resource_info['master'][0]['port'][0]))
       

--- a/parallax/parallax/core/python/common/runner.py
+++ b/parallax/parallax/core/python/common/runner.py
@@ -73,15 +73,15 @@ def _parallax_run_master(single_gpu_meta_graph_def,
     search_p = False
     p_to_test = None
     if config.search_partitions and PARALLAX_MIN_PARTITIONS in os.environ:
-      # Set to find automatic embedding partitoning
-      p_to_test = len(config.resource_info['worker'])
-      min_partitions = int(os.environ[PARALLAX_MIN_PARTITIONS])
-      p_to_test = max(min_partitions, p_to_test)
-      address = (config.resource_info['master'][0]['hostname'],
-                 int(config.resource_info['master'][0]['port'][0]))
+        # Set to find automatic embedding partitoning
+        p_to_test = len(config.resource_info['worker'])
+        min_partitions = int(os.environ[PARALLAX_MIN_PARTITIONS])
+        p_to_test = max(min_partitions, p_to_test)
+        address = (config.resource_info['master'][0]['hostname'],
+                   int(config.resource_info['master'][0]['port'][0]))
       
-      stat_collector = PartitionStatCollector(p_to_test, address)
-      search_p = True
+        stat_collector = PartitionStatCollector(p_to_test, address)
+        search_p = True
 
     cleanup = None
     try:
@@ -92,7 +92,8 @@ def _parallax_run_master(single_gpu_meta_graph_def,
 
 	    if config.run_option == 'MPI' or \
 		(config.run_option == 'HYBRID' and len(sparse_grads) == 0):
-		num_workers = sum([max(1, len(w['gpus'])) for w in config.resource_info['worker']])
+                num_workers = sum([max(1, len(w['gpus'])) for w in \
+                    config.resource_info['worker']])
 		processes, cleanup = \
 			launch_mpi_driver(driver_path,
 					  args,
@@ -116,6 +117,8 @@ def _parallax_run_master(single_gpu_meta_graph_def,
 					 config,
                                          p_to_test,
                                          m)
+            else:
+                raise ValueError("Run option must be one of MPI, PS or HYBRID")
 
 	    if not search_p:
 		processes[0].wait()

--- a/parallax/parallax/core/python/mpi/runner.py
+++ b/parallax/parallax/core/python/mpi/runner.py
@@ -29,10 +29,12 @@ import horovod.tensorflow as hvd
 
 from parallax.core.python.common.lib import *
 from parallax.core.python.common.consts import *
+from parallax.core.python.common.partitions import *
 from parallax.core.python.common.session_context import ParallaxSessionContext
 from parallax.core.python.mpi.graph_transform import graph_transform_mpi
 
-def create_mpi_script(driver_path, args, hostname, gpus, port=22):
+def create_mpi_script(driver_path, args, hostname, gpus, partitions, search,
+                      port=22):
 
     cmd = 'ssh -p %d %s "mkdir -p %s"' % (port, hostname, REMOTE_PARALLAX_ROOT)
     parallax_log.warning(colored('\n$ %s' % cmd, 'red'))
@@ -49,7 +51,10 @@ def create_mpi_script(driver_path, args, hostname, gpus, port=22):
         "CUDA_VISIBLE_DEVICES": ','.join(str(gpuid) for gpuid in gpus),
         "PARALLAX_LOG_LEVEL": parallax_log_level,
         PARALLAX_HOSTNAME: hostname,
+        PARALLAX_SEARCH: search,
     }
+    if partitions:
+         env[PARALLAX_PARTITIONS] = partitions
 
     cmd_env = ' '.join(
         map(lambda (k, v): 'export %s=%s;' % (k, v), env.iteritems()))
@@ -69,13 +74,14 @@ def create_mpi_script(driver_path, args, hostname, gpus, port=22):
     proc.wait()
 
 
-def _prepare_workers(workers, driver_path, args):
+def _prepare_workers(workers, driver_path, args, partitions, search):
     for worker in workers:
-        _prepare_worker(worker, driver_path, args)
+        _prepare_worker(worker, driver_path, args, partitions, search)
 
 
-def _prepare_worker(worker, driver_path, args):
-    create_mpi_script(driver_path, args, worker['hostname'], worker['gpus'])
+def _prepare_worker(worker, driver_path, args, partitions, search):
+    create_mpi_script(driver_path, args, worker['hostname'], worker['gpus'],
+                      partitions, search)
 
 
 def _get_mpi_cmd(config):
@@ -103,20 +109,25 @@ def _get_mpi_cmd(config):
     return mpi_cmd
 
 
-def launch_mpi_driver(driver_path, args, config):
+def launch_mpi_driver(driver_path, args, config, partitions, m):
     workers = config.resource_info['worker']
-    _prepare_workers(workers, driver_path, args)
+    _prepare_workers(workers, driver_path, args, partitions, m is not None)
 
     mpi_cmd = _get_mpi_cmd(config)
 
     parallax_log.warning(colored('\n$ %s' % mpi_cmd, 'red'))
-    proc = subprocess.Popen(args=mpi_cmd, shell=True)
+    proc = subprocess.Popen(args=mpi_cmd, shell=True, preexec_fn=os.setsid)
 
     def cleanup_mpi(recv_signal, frame):
-        proc.kill()
+        if m:
+            m.shutdown()
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGINT)
+        except:
+            pass
 
     signal.signal(signal.SIGINT, cleanup_mpi)
-    return proc, cleanup_mpi
+    return [proc], cleanup_mpi
 
 
 def _init_global_vars(sess):
@@ -194,6 +205,7 @@ def parallax_run_mpi(single_gpu_meta_graph_def, config):
                                    config.profile_config.profile_steps,
                                    config.profile_config.profile_range,
                                    tensor_or_op_name_to_replica_names,
-                                   1)
+                                   1,
+                                   config.resource_info['master'][0])
         sess_context.set_parallax_session_context()
         return sess, num_workers, worker_id, 1

--- a/parallax/parallax/core/python/ps/runner.py
+++ b/parallax/parallax/core/python/ps/runner.py
@@ -27,9 +27,9 @@ import tensorflow as tf
 from parallax.core.python.common import graph_transform_lib
 from parallax.core.python.common.lib import *
 from parallax.core.python.common.consts import *
+from parallax.core.python.common.partitions import *
 from parallax.core.python.common.session_context import ParallaxSessionContext
 from parallax.core.python.ps.graph_transform import graph_transform_ps
-
 
 def _create_log_files(redirect_path, job, task_id):
     directory = os.path.dirname(redirect_path)
@@ -113,7 +113,7 @@ def _get_launch_worker_cmd(driver_path, args):
     return cmd
 
 
-def _get_worker_env(worker_id, config):
+def _get_worker_env(worker_id, config, partitions, search):
     workers = config.resource_info['worker']
     worker_info = workers[worker_id]
     num_workers = len(workers)
@@ -128,17 +128,20 @@ def _get_worker_env(worker_id, config):
         PARALLAX_RUN_OPTION: PARALLAX_RUN_PS,
         PARALLAX_RESOURCE_INFO: serialize_resource_info(config.resource_info),
         PARALLAX_WORKER_ID: worker_id,
-        PARALLAX_NUM_WORKERS: num_workers
+        PARALLAX_NUM_WORKERS: num_workers,
+        PARALLAX_SEARCH: search,
     }
+    if partitions:
+        env[PARALLAX_PARTITIONS] = partitions
 
     return env
 
 
-def launch_worker(driver_path, args, worker_id, config):
+def launch_worker(driver_path, args, worker_id, config, partitions, search):
     worker_info = config.resource_info['worker'][worker_id]
 
     cmd = _get_launch_worker_cmd(driver_path, args)
-    env = _get_worker_env(worker_id, config)
+    env = _get_worker_env(worker_id, config, partitions, search)
 
     # TODO: better mechanism for managing log files
     if config.redirect_path is not None:
@@ -157,7 +160,7 @@ def launch_worker(driver_path, args, worker_id, config):
         logfiles
 
 
-def launch_ps_driver(driver_path, args, config):
+def launch_ps_driver(driver_path, args, config, partitions, m):
     workers = config.resource_info['worker']
     pss = config.resource_info['ps'] if 'ps' in config.resource_info else []
 
@@ -167,11 +170,13 @@ def launch_ps_driver(driver_path, args, config):
     for worker_id in range(len(workers)):
         worker_proc, worker_logs =\
             launch_worker(driver_path, args, len(workers) - worker_id - 1,
-                          config)
+                          config, partitions, m is not None)
         logfiles += worker_logs
         if worker_id == 0:
             chief_worker_process = worker_proc
-        processes.append(worker_proc)
+            processes.insert(0, worker_proc)
+        else:
+            processes.append(worker_proc)
 
     for ps_id in range(len(pss)):
         ps_proc, ps_logs = launch_ps(ps_id, config)
@@ -179,12 +184,13 @@ def launch_ps_driver(driver_path, args, config):
         processes.append(ps_proc)
 
     def cleanup_ps(recv_signal, frame):
+        if m is not None:
+            m.shutdown()
         for process in processes:
             os.killpg(os.getpgid(process.pid), signal.SIGINT)
 
     signal.signal(signal.SIGINT, cleanup_ps)
-    return chief_worker_process, logfiles, cleanup_ps
-
+    return processes, logfiles, cleanup_ps
 
 def _get_worker_info():
     worker_id = int(os.getenv(PARALLAX_WORKER_ID, -1))
@@ -283,7 +289,8 @@ def parallax_run_ps(single_gpu_meta_graph_def, config):
                                               config.profile_config.profile_steps,
                                               config.profile_config.profile_range,
                                               tensor_or_op_name_to_replica_names,
-                                              num_replicas_per_worker)
+                                              num_replicas_per_worker,
+                                              config.resource_info['master'][0])
         sess_context.set_parallax_session_context()
         return sess, num_workers, worker_id, num_replicas_per_worker
 

--- a/parallax/parallax/examples/lm1b/README.md
+++ b/parallax/parallax/examples/lm1b/README.md
@@ -35,6 +35,7 @@ Also, we have a few more options you can choose for distributed running.
 | --save_ckpt_steps    | 0						| Number of steps between two consecutive checkpoints |
 | --save_n_ckpts_per_epoch | -1					| Number of checkpoints to save per each epoch |
 | --run_option		   | None					| The run option whether PS or MPI, None utilizes both |
+| --search_partitions | False           | Whether to use Parallax's partitioning method or not 
 
 You can adapt the distributed running with above options. For example, if you want to fix the communication model as MPI mode, you can add `run_option` value like below.
 

--- a/parallax/parallax/examples/lm1b/README.md
+++ b/parallax/parallax/examples/lm1b/README.md
@@ -35,7 +35,7 @@ Also, we have a few more options you can choose for distributed running.
 | --save_ckpt_steps    | 0						| Number of steps between two consecutive checkpoints |
 | --save_n_ckpts_per_epoch | -1					| Number of checkpoints to save per each epoch |
 | --run_option		   | None					| The run option whether PS or MPI, None utilizes both |
-| --search_partitions | False           | Whether to use Parallax's partitioning method or not 
+| --search_partitions | False           | Whether to use Parallax's variable partitioning method or not 
 
 You can adapt the distributed running with above options. For example, if you want to fix the communication model as MPI mode, you can add `run_option` value like below.
 

--- a/parallax/parallax/examples/lm1b/language_model.py
+++ b/parallax/parallax/examples/lm1b/language_model.py
@@ -33,16 +33,16 @@ class LM(base.Layer):
   def build(self, input_shape):
     partitioner = parallax.get_partitioner(self.num_shards)
     with tf.variable_scope(tf.get_variable_scope(), partitioner=partitioner):
-        self.emb = tf.get_variable('emb', 
-                                   shape=[self.vocab_size, self.emb_size],
-                                   initializer=tf.uniform_unit_scaling_initializer(),
-                                   trainable=True,
-                                   dtype=tf.float32)
-        self.softmax_w = tf.get_variable(name='softmax_w',
-                                        shape=[self.vocab_size, self.projected_size],
-                                        initializer=tf.uniform_unit_scaling_initializer(),
-                                        trainable=True,
-                                        dtype=tf.float32)
+      self.emb = tf.get_variable('emb', 
+                                 shape=[self.vocab_size, self.emb_size],
+                                 initializer=tf.uniform_unit_scaling_initializer(),
+                                 trainable=True,
+                                 dtype=tf.float32)
+      self.softmax_w = tf.get_variable(name='softmax_w',
+                                       shape=[self.vocab_size, self.projected_size],
+                                       initializer=tf.uniform_unit_scaling_initializer(),
+                                       trainable=True,
+                                       dtype=tf.float32)
 
     self.softmax_b = self.add_variable(name='softmax_b',
                                        shape=[self.vocab_size],

--- a/parallax/parallax/examples/lm1b/language_model_graph.py
+++ b/parallax/parallax/examples/lm1b/language_model_graph.py
@@ -38,9 +38,9 @@ def build_model():
     loss, final_state_c, final_state_h = model(placeholder_x, placeholder_y, placeholder_w, initial_state_c, initial_state_h, training=True)
     scaled_loss = loss * FLAGS.num_steps
 
-    emb_vars = model.emb
+    emb_vars = list(model.emb)
     lstm_vars = [model.W, model.B, model.W_P]
-    softmax_vars = model.softmax_w + [model.softmax_b]
+    softmax_vars = list(model.softmax_w) + [model.softmax_b]
     all_vars = emb_vars + lstm_vars + softmax_vars
     grads = tf.gradients(scaled_loss, all_vars)
 

--- a/parallax/parallax/examples/lm1b/parallax_config.py
+++ b/parallax/parallax/examples/lm1b/parallax_config.py
@@ -37,6 +37,7 @@ flags.DEFINE_boolean('boundary_among_servers', True,
 flags.DEFINE_boolean('boundary_between_workers_and_servers', True,
                      """Whether to use operation placement between workers and servers""")
 flags.DEFINE_string('export_graph_path', None, """export path to keep transformed graph definintion""")
+flags.DEFINE_boolean('search_partitions', False, "Whether to use find near-optimal partitions")
 FLAGS = flags.FLAGS
 
 def build_config():
@@ -75,5 +76,6 @@ def build_config():
     parallax_config.profile_config = profile_config
     parallax_config.redirect_path = FLAGS.redirect_path
     parallax_config.export_graph_path = FLAGS.export_graph_path
+    parallax_config.search_partitions = FLAGS.search_partitions
 
     return parallax_config

--- a/parallax/parallax/examples/lm1b/parallax_config.py
+++ b/parallax/parallax/examples/lm1b/parallax_config.py
@@ -37,7 +37,7 @@ flags.DEFINE_boolean('boundary_among_servers', True,
 flags.DEFINE_boolean('boundary_between_workers_and_servers', True,
                      """Whether to use operation placement between workers and servers""")
 flags.DEFINE_string('export_graph_path', None, """export path to keep transformed graph definintion""")
-flags.DEFINE_boolean('search_partitions', False, "Whether to use find near-optimal partitions")
+flags.DEFINE_boolean('search_partitions', False, "Whether to use variable partitioning method")
 FLAGS = flags.FLAGS
 
 def build_config():

--- a/parallax/parallax/examples/nmt/README.md
+++ b/parallax/parallax/examples/nmt/README.md
@@ -45,7 +45,7 @@ Besides, we have a few more options you can choose for distributed running.
 | --save_ckpt_steps    | 0						| Number of steps between two consecutive checkpoints |
 | --run_option		   | None					| The run option whether PS or MPI, None utilizes both |
 | --epoch_size 		   | 0						| total number of data instances |
-| --search_partitions   | False              | Whether to use Parallax's partitioning method or not |
+| --search_partitions   | False              | Whether to use Parallax's variable partitioning method or not |
 
 You can adapt the distributed running with above options. For example, you can run the GNMT WMT German-English model in MPI mode by just adding `--run_option` value to the script like below:
 

--- a/parallax/parallax/examples/nmt/README.md
+++ b/parallax/parallax/examples/nmt/README.md
@@ -45,6 +45,7 @@ Besides, we have a few more options you can choose for distributed running.
 | --save_ckpt_steps    | 0						| Number of steps between two consecutive checkpoints |
 | --run_option		   | None					| The run option whether PS or MPI, None utilizes both |
 | --epoch_size 		   | 0						| total number of data instances |
+| --search_partitions   | False              | Whether to use Parallax's partitioning method or not |
 
 You can adapt the distributed running with above options. For example, you can run the GNMT WMT German-English model in MPI mode by just adding `--run_option` value to the script like below:
 

--- a/parallax/parallax/examples/nmt/model_helper.py
+++ b/parallax/parallax/examples/nmt/model_helper.py
@@ -8,6 +8,7 @@ import time
 
 import numpy as np
 import tensorflow as tf
+import parallax
 
 from tensorflow.python.ops import lookup_ops
 
@@ -305,15 +306,9 @@ def create_emb_for_encoder_and_decoder(share_vocab,
     ValueError: if use share_vocab but source and target have different vocab
       size.
   """
-
-  if num_partitions <= 1:
-    partitioner = None
-  else:
-    # Note: num_partitions > 1 is required for distributed training due to
-    # embedding_lookup tries to colocate single partition-ed embedding variable
-    # with lookup ops. This may cause embedding variables being placed on worker
-    # jobs.
-    partitioner = tf.fixed_size_partitioner(num_partitions)
+  partitioner = None
+  if num_partitions > 0:
+      partitioner = parallax.get_partitioner(num_partitions)
 
   if (src_embed_file or tgt_embed_file) and partitioner:
     raise ValueError(

--- a/parallax/parallax/examples/nmt/parallax_config.py
+++ b/parallax/parallax/examples/nmt/parallax_config.py
@@ -39,7 +39,7 @@ flags.DEFINE_boolean('boundary_among_servers', True,
 flags.DEFINE_boolean('boundary_between_workers_and_servers', True,
                      """Whether to use operation placement between workers and servers""")
 flags.DEFINE_string('export_graph_path', None, """export path to keep transformed graph definintion""")
-flags.DEFINE_boolean('search_partitions', False, "Whether to use find near-optimal partitions")
+flags.DEFINE_boolean('search_partitions', False, """Whether to use variable partitioning method""")
 FLAGS = flags.FLAGS
 
 def calculate_ckpt_steps():

--- a/parallax/parallax/examples/nmt/parallax_config.py
+++ b/parallax/parallax/examples/nmt/parallax_config.py
@@ -39,6 +39,7 @@ flags.DEFINE_boolean('boundary_among_servers', True,
 flags.DEFINE_boolean('boundary_between_workers_and_servers', True,
                      """Whether to use operation placement between workers and servers""")
 flags.DEFINE_string('export_graph_path', None, """export path to keep transformed graph definintion""")
+flags.DEFINE_boolean('search_partitions', False, "Whether to use find near-optimal partitions")
 FLAGS = flags.FLAGS
 
 def calculate_ckpt_steps():
@@ -82,5 +83,6 @@ def build_config():
     parallax_config.profile_config = profile_config
     parallax_config.redirect_path = FLAGS.redirect_path
     parallax_config.export_graph_path = FLAGS.export_graph_path
+    parallax_config.search_partitions = FLAGS.search_partitions
 
     return parallax_config

--- a/parallax/parallax/util/setup.py
+++ b/parallax/parallax/util/setup.py
@@ -123,6 +123,7 @@ REQUIRED_PACKAGES = [
     'protobuf >= 3.3.0',
     'nltk >= 3.0.0',
     'ephemeral-port-reserve',
+    'scipy >= 1.1.0',
 ]
 
 TEST_PACKAGES = [


### PR DESCRIPTION
Github issue: #24 

**Major changes:**
- Enable automatic variable partitioning using `get_partitioner` API.

**Minor changes to note:**
- LM and NMT codes are fixed to apply the partitioning

**Tests for the changes:**
- Run LM or NMT with `search_partitions=True`

**Other comments:**
- To run NMT, pass `num_embeddings_partitions` with the number larger than zero. 
Otherwise, partitioner is not used at all.

resolves #24 
