### PR TITLE
[MINOR] Fix step number of saved `run_meta` file

### DIFF
--- a/parallax/parallax/core/python/hybrid/runner.py
+++ b/parallax/parallax/core/python/hybrid/runner.py
@@ -266,6 +266,7 @@ def parallax_run_hybrid(single_gpu_meta_graph_def,
         step = sess.run(tf.get_collection(tf.GraphKeys.GLOBAL_STEP)[0])
         sess_context = \
             ParallaxSessionContext(step,
+                                   tf.get_collection(tf.GraphKeys.GLOBAL_STEP)[0],
                                    config.profile_config.profile_dir,
                                    config.profile_config.profile_steps,
                                    config.profile_config.profile_range,

--- a/parallax/parallax/core/python/mpi/runner.py
+++ b/parallax/parallax/core/python/mpi/runner.py
@@ -201,6 +201,7 @@ def parallax_run_mpi(single_gpu_meta_graph_def, config):
         step = sess.run(tf.get_collection(tf.GraphKeys.GLOBAL_STEP)[0])
         sess_context = \
             ParallaxSessionContext(step,
+                                   tf.get_collection(tf.GraphKeys.GLOBAL_STEP)[0],
                                    config.profile_config.profile_dir,
                                    config.profile_config.profile_steps,
                                    config.profile_config.profile_range,

--- a/parallax/parallax/core/python/ps/runner.py
+++ b/parallax/parallax/core/python/ps/runner.py
@@ -285,6 +285,7 @@ def parallax_run_ps(single_gpu_meta_graph_def, config):
 
         step = sess.run(tf.get_collection(tf.GraphKeys.GLOBAL_STEP)[0])
         sess_context = ParallaxSessionContext(step,
+                                              tf.get_collection(tf.GraphKeys.GLOBAL_STEP)[0],
                                               config.profile_config.profile_dir,
                                               config.profile_config.profile_steps,
                                               config.profile_config.profile_range,


### PR DESCRIPTION
Github issue: #26 

**Major changes:**
- Fetched `global_step` value is used when Parallax saves `run_meta` files.

**Minor changes to note:**
- None

**Tests for the changes:**
- Run any example app code with profiling options.

**Other comments:**
- None

resolves #26 
