### PR TITLE
[MINOR] Make all workers to be targets of profiling by default 

### DIFF
--- a/parallax/parallax/core/python/common/config.py
+++ b/parallax/parallax/core/python/common/config.py
@@ -108,7 +108,7 @@ class ProfileConfig(object):
                  profile_dir=None,
                  profile_steps=None,
                  profile_range=None,
-                 profile_worker=0):
+                 profile_worker=None):
         """
         Args:
           profile_dir: The profile directory to store RunMetadata.

--- a/parallax/parallax/core/python/common/lib.py
+++ b/parallax/parallax/core/python/common/lib.py
@@ -330,8 +330,7 @@ class TensorOrOpNameToReplicaNames(object):
     def export(self):
         return self._mapping
 
-def create_profile_directory(profile_dir, profile_worker, 
-                             resource_info, hostname):
+def create_profile_directory(profile_dir, resource_info, hostname):
     if not profile_dir:
       return
 

--- a/parallax/parallax/core/python/hybrid/runner.py
+++ b/parallax/parallax/core/python/hybrid/runner.py
@@ -186,7 +186,6 @@ def parallax_run_hybrid(single_gpu_meta_graph_def,
     num_workers = hvd.size()
     machine_id, hostname = _get_worker_info()
     create_profile_directory(config.profile_config.profile_dir,
-                             config.profile_config.profile_worker,
                              config.resource_info, hostname)
 
     sess_config = config.sess_config
@@ -232,7 +231,7 @@ def parallax_run_hybrid(single_gpu_meta_graph_def,
                                 'worker:%d'%worker_id)
             export_meta_graph(path, worker_id)
 
-            if worker_id != config.profile_config.profile_worker:
+            if config.profile_config.profile_worker != None and worker_id != config.profile_config.profile_worker:
                 #Only one CUPTI profiler can run in a machine
                 #See tensorflow/tensorflow/core/platform/default/device_tracer.cc:L452
                 config.profile_config.profile_dir = None

--- a/parallax/parallax/core/python/hybrid/runner.py
+++ b/parallax/parallax/core/python/hybrid/runner.py
@@ -59,7 +59,7 @@ def create_mpi_script(driver_path, args, hostname, gpus, resource_info,
         map(lambda (k, v): 'export %s=%s;' % (k, v), env.iteritems()))
     try:
         cmd_venv = ' source %s/bin/activate; '\
-                    % os.environ['VIRTUAL_ENV_PATH']
+                    % os.environ['VIRTUAL_ENV']
         full_cmd = ' '.join([cmd_env, cmd_venv, cmd_run])
     except:
         full_cmd = ' '.join([cmd_env, cmd_run])

--- a/parallax/parallax/core/python/mpi/runner.py
+++ b/parallax/parallax/core/python/mpi/runner.py
@@ -141,7 +141,6 @@ def _init_global_vars(sess):
 def parallax_run_mpi(single_gpu_meta_graph_def, config):
     hostname = os.getenv(PARALLAX_HOSTNAME, 0)
     create_profile_directory(config.profile_config.profile_dir,
-                             config.profile_config.profile_worker,
                              config.resource_info, hostname)
 
     mpi_meta_graph_def, tensor_or_op_name_to_replica_names = \
@@ -166,7 +165,7 @@ def parallax_run_mpi(single_gpu_meta_graph_def, config):
                                 'worker:%d'%worker_id)
             export_meta_graph(path, worker_id)
             
-            if worker_id != config.profile_config.profile_worker:
+            if config.profile_config.profile_worker != None and worker_id != config.profile_config.profile_worker:
                 #Only one CUPTI profiler can run in a machine
                 #See tensorflow/tensorflow/core/platform/default/device_tracer.cc:L452
                 config.profile_config.profile_dir = None

--- a/parallax/parallax/core/python/ps/runner.py
+++ b/parallax/parallax/core/python/ps/runner.py
@@ -209,7 +209,6 @@ def parallax_run_ps(single_gpu_meta_graph_def, config):
     worker = config.resource_info['worker'][worker_id]
 
     create_profile_directory(config.profile_config.profile_dir, 
-                             config.profile_config.profile_worker,
                              config.resource_info, worker['hostname'])
     num_replicas_per_worker = len(worker['gpus'])
     if config.profile_config.profile_dir:
@@ -220,7 +219,7 @@ def parallax_run_ps(single_gpu_meta_graph_def, config):
                                  ['worker:%d'%worker_id, 'ps:%d'%ps_i])
                 break
          
-        if worker_id != config.profile_config.profile_worker:
+        if config.profile_config.profile_worker != None and worker_id != config.profile_config.profile_worker:
             config.profile_config.profile_dir = None
 
     parallax_log.debug("Launching server on worker %d" % worker_id)

--- a/parallax/parallax/examples/tf_cnn_benchmarks/parallax_config.py
+++ b/parallax/parallax/examples/tf_cnn_benchmarks/parallax_config.py
@@ -33,7 +33,7 @@ flags.DEFINE_string('ckpt_dir', None, """Directory to save checkpoints""")
 flags.DEFINE_string('profile_dir', None, """Directory to save RunMetadata""")
 flags.DEFINE_string('profile_steps', None, """Comma separated porfile steps""")
 flags.DEFINE_string('profile_range', None, """profile_start_step,profile_end_step""")
-flags.DEFINE_integer('profile_worker', 0, """The worker to profile""")
+flags.DEFINE_integer('profile_worker', None, """The worker to profile""")
 flags.DEFINE_boolean('local_aggregation', True,
                      """Whether to use local aggregation or not""")
 flags.DEFINE_boolean('boundary_among_servers', True,


### PR DESCRIPTION
**Major changes:**
- Make all workers be targets of profiling by default
- If profile_worker is not set (None), all workers become targets of profiling.